### PR TITLE
Dynamic model base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Models can specify an alternate location by setting `Model.settings.components` 
 
 All paths are relative to your project root (or the value of the `basePath` component configuration option).
 
+If you are using server-only models, set `modelPath` to `server/models`
+
 All model customization carried out by this component takes place after all models have been initialized and attached to the app (but before boot scripts run). This ensures that all models are already available on the app at the time the customizations are applied.
 
 ## Installation
@@ -42,7 +44,9 @@ All model customization carried out by this component takes place after all mode
 
   [String] : Directory containing loopback application. *(default: null)*
 
+- `modelPath`
 
+  [String] : Directory containing loopback models. *(default: 'common/models')*
 
 ## Testing
 

--- a/index.js
+++ b/index.js
@@ -49,7 +49,8 @@ module.exports = (app, options) => {
 
     // Determine the path to look for model a customisation file.
     const basePath = path.join(appRoot.toString(), (options.basePath || '.'))
-    const componentsPath = Model.settings.components || `common/models/${kebabCase(Model.modelName)}`
+    const modelPath = options.modelPath || `common/models`
+    const componentsPath = Model.settings.components || `${modelPath}/${kebabCase(Model.modelName)}`
     const requirePath = path.join(basePath, componentsPath)
 
     try {


### PR DESCRIPTION
I've run into problems using this component when models are located in `server/models`. Therefore I've created a config option `modelPath`. The option is defaulting to `common/models` to preserve backward compatibilty.

Best Regards,
Frido