### PR TITLE
feat: support for loading .ts files

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = (app, options) => {
       requireAll({
         dirname,
         recursive: false,
+        filter:/^([^\.].*)\.(js|ts|json)?$/,
         resolve: code => {
           debug('Loading customization script %s', code)
           if (typeof code === 'function') {


### PR DESCRIPTION
With [ts-node](https://github.com/TypeStrong/ts-node), we can use .ts file for model customization. So I change the default filter of [require-all](https://github.com/felixge/node-require-all)